### PR TITLE
Fixed package prefix for CentOS 5

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -17,12 +17,21 @@
 #
 define yum::plugin (
   $ensure     = present,
-  $pkg_prefix = 'yum-plugin',
+  $pkg_prefix = undef,
   $pkg_name   = ''
 ) {
+
+  if $pkg_prefix {
+    $_pkg_prefix = $pkg_prefix
+  } else {
+    $_pkg_prefix = "${::operatingsystem}${::operatingsystemmajrelease}" ? {
+      'CentOS5' => 'yum',
+      default   => 'yum-plugin'
+    }
+  }
   $_pkg_name = $pkg_name ? {
-    ''      => "${pkg_prefix}-${name}",
-    default => "${pkg_prefix}-${pkg_name}"
+    ''      => "${_pkg_prefix}-${name}",
+    default => "${_pkg_prefix}-${pkg_name}"
   }
 
   package { $_pkg_name:


### PR DESCRIPTION
The package didn't work for CentOS 5. I've fixed it.