### PR TITLE
increase stdlib requirement to 4.2.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0"}
   ]
 }


### PR DESCRIPTION
the delete_undef_values() function was [added in 4.2.0](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/CHANGELOG.md#2014-05-08---release---420)

related to issue #8