### PR TITLE
Add ability to use 'yum localinstall packagename'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ yum::group { 'X Window System':
 }
 ```
 
+### yum::localinstall
+
+Install or remove packages via *yum* localinstall subcommand:
+
+```puppet
+# From URL
+yum::localinstall { 'package-name':
+  ensure => present,
+  rpm_source => 'http://path/to/package/filename.rpm',
+}
+```
+
+```puppet
+# From Local Filesystem
+yum::localinstall { 'package-name':
+  ensure => present,
+  rpm_source => '/path/to/package/filename.rpm',
+}
+```
+
+Please note that the title must be the package name as it is referenced in the
+package manager after it is installed.
+
+
 ***
 
 CERIT Scientific Cloud, <support@cerit-sc.cz>

--- a/manifests/localinstall.pp
+++ b/manifests/localinstall.pp
@@ -1,0 +1,58 @@
+# Define: yum::localinstall
+#
+# This definition installs or removes rpm's via file or url (e.g. not a repo).
+# This can be prefereable to using just the rpm provider because it will pull
+# in dependencies if available.
+#
+# Parameters:
+#   [*ensure*]   - specifies if package group should be
+#                  present (installed) or absent (purged)
+#   [rpm_source] - file or url where RPM is available to the puppet agent.
+#
+# Actions:
+#
+# Requires:
+#   RPM based system
+#
+# Sample usage:
+#   yum::localinstall { 'epel-release':
+#     ensure     => present,
+#     rpm_source => 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',
+#   }
+#
+define yum::localinstall (
+  $rpm_source = undef,
+  $ensure = present
+) {
+
+  $install_message = 'Please note the resource title needs to be the same as the package name listed in the package manager.'
+
+  Exec {
+    path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+    environment => 'LC_ALL=C'
+  }
+
+  if $rpm_source == undef {
+    fail('Please pass a URI to an RPM you wish to install.')
+  }
+
+
+  case $ensure {
+    present,installed: {
+      exec { "yum-localinstall-${name}":
+        command => "yum -y localinstall '${rpm_source}'; echo '${install_message}'",
+        unless  => "yum -q list installed '${name}' | egrep -i '${name}'",
+      }
+    }
+
+    absent,purged: {
+      package { $name:
+        ensure => $ensure,
+      }
+    }
+
+    default: {
+      fail("Invalid ensure state: ${ensure}")
+    }
+  }
+}

--- a/tests/localinstall.pp
+++ b/tests/localinstall.pp
@@ -1,0 +1,16 @@
+
+if "${::osfamily}" == 'RedHat' { # lint:ignore:only_variable_string
+
+  # https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  # https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+  # https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+
+  $rpm_source =  "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${::operatingsystemmajrelease}.noarch.rpm"
+
+
+  yum::localinstall { 'epel-release':
+    ensure     => present,
+    rpm_source => $rpm_source,
+  }
+
+}


### PR DESCRIPTION
Tried to stay as close to style of the yum::group class as possible.  Not super complicated.  Works in my use cases for install and removal.

I used the epel-release package for tests and examples because I wanted something pretty standard and relatively benign.  Any suggestions for a better test case?