### PR TITLE
Adding hidden option to grouplist command

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -28,14 +28,14 @@ define yum::group (
     present,installed: {
       exec { "yum-groupinstall-${name}":
         command => "yum -y groupinstall '${name}'",
-        unless  => "yum grouplist '${name}' | egrep -i '^Installed.+Groups:$'",
+        unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
       }
     }
 
     absent,purged: {
       exec { "yum-groupremove-${name}":
         command => "yum -y groupremove '${name}'",
-        onlyif  => "yum grouplist '${name}' | egrep -i '^Installed.+Groups:$'",
+        onlyif  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
       }
     }
 


### PR DESCRIPTION
Added hidden option to the grouplist command so that Puppet will not continually try and install hidden groups and this will give it the ability to remove installed hidden groups.
